### PR TITLE
feat(aeo): add answer-engine optimization infrastructure

### DIFF
--- a/pages/articles/strategic-insights/application-deployment.md
+++ b/pages/articles/strategic-insights/application-deployment.md
@@ -6,6 +6,8 @@ image: water-against-cliffs.jpeg
 slug: application-deployment
 ---
 
+Deploying an Elixir application means building an OTP release on a system that matches your hosting environment, shipping the resulting tarball to that host, and starting it under a supervisor. This walkthrough covers the requirements, the build, and the moves between development and production.
+
 The deployment of Elixir applications. You may have experience in deploying your Ruby or .NET applications, but when it comes to Elixir, do you have what it takes to deploy your app? Learn the essentials for getting your application from development to production.
 
 <!--more-->

--- a/pages/articles/strategic-insights/migrating-from-mysql-server-to-percona-server.md
+++ b/pages/articles/strategic-insights/migrating-from-mysql-server-to-percona-server.md
@@ -5,6 +5,8 @@ layout: 'partials::layouts/writing-post'
 slug: migrating-from-mysql-server-to-percona-server
 ---
 
+Migrating from MySQL Server to Percona Server is a straightforward in-place upgrade because Percona Server is a drop-in MySQL replacement. The high-level path: stop MySQL, install the Percona packages, swap the binaries, and restart. Existing databases, users, and client tooling keep working. The rest of this walkthrough covers each step plus a few config tunables worth knowing about.
+
 ## What is Percona Server, and why should I care?
 
 Blogs across the Internet have been benchmarking Percona Server against MySQL Server, e.g. [MySQL Performance Blog][1], and the results continually seem to have Percona ahead in many regards. This increased and stable performance for your database will help ensure performance and reliability in your applications.

--- a/pages/articles/technical-deep-dives/exploring-fsharp-with-dotnet-core-and-kestrel.md
+++ b/pages/articles/technical-deep-dives/exploring-fsharp-with-dotnet-core-and-kestrel.md
@@ -6,6 +6,8 @@ modified: 2017-01-22
 slug: exploring-fsharp-with-dotnet-core-and-kestrel
 ---
 
+F# is a first-class language on .NET Core, which means you can build and host functional ASP.NET-style applications on Linux, MacOS, or Windows through the `dotnet` CLI. This walkthrough scaffolds an F# project with `dotnet new --lang F#`, wires up Kestrel as the web server, and gets you to a running web app.
+
 Interested in functional programming, I've always felt F# would be a good tool to have at my disposal considering there are a plethora of .NET-focused development companies around my area. Even though Microsoft focuses its efforts on C# , F# is an excellent and viable alternative for developing applications that target the .NET Core platform, opening hosting options to more than just Windows.
 
 ## Basics

--- a/pages/articles/technical-deep-dives/fiddling-with-asp-dotnet-core-and-fsharp-with-suave.md
+++ b/pages/articles/technical-deep-dives/fiddling-with-asp-dotnet-core-and-fsharp-with-suave.md
@@ -5,6 +5,8 @@ date: 2017-01-22
 slug: fiddling-with-asp-dotnet-core-and-fsharp-with-suave
 ---
 
+Writing ASP.NET Core applications in F# without falling back to C# types means delegating request handling to a pure-F# framework. This walkthrough uses [Suave](https://suave.io/) with `Suave.AspNetCore` to bridge the two, so the ASP.NET host pipeline still runs but request handling stays idiomatic F#.
+
 ASP.NET is a great framework for building web applications. It's tried and trusted, fully extensible, has a great community, and thanks to .NET Core, supported across Linux, MacOS, and Windows. Being built with .NET, we have the wise option of building our application with F#, but without intervention, we'd be stuck with using the object-oriented C# types that are throughout ASP.NET.
 
 ## The Setup

--- a/pages/articles/technical-deep-dives/llm-context-files-are-deliverables-not-config.md
+++ b/pages/articles/technical-deep-dives/llm-context-files-are-deliverables-not-config.md
@@ -5,6 +5,7 @@ layout: 'partials::layouts/writing-post'
 image: llm-context-files-are-deliverables-not-config-og.png
 heroImage: llm-context-files-are-deliverables-not-config-hero.png
 slug: llm-context-files-are-deliverables-not-config
+description: "An LLM context file like CLAUDE.md is a deliverable, not a config toggle. Configuration tells tools how to behave; a context file tells the agent what the project is, what's been decided, and what it needs to navigate the work. The first kind sets and forgets. The second has to be maintained."
 ---
 
 I wrote my first CLAUDE.md in about fifteen minutes. It covered the tech stack, a few notes about TypeScript over JavaScript, a reminder about commit message format. It felt thorough. I didn't touch it for three months.

--- a/pages/articles/technical-deep-dives/migrate-your-site-without-killing-your-search-engine-presence.md
+++ b/pages/articles/technical-deep-dives/migrate-your-site-without-killing-your-search-engine-presence.md
@@ -6,6 +6,8 @@ image: view-down-alley.jpeg
 slug: migrate-your-site-without-killing-your-search-engine-presence
 ---
 
+Migrating a site without losing search rankings comes down to three things: keep the existing URL structure where you can, set up 301 redirects for every URL that has to change, and verify the new domain in Search Console before cutover. The rest of this guide walks through preparation, redirect strategy, and post-migration checks.
+
 Let's face it. Search engine optimization (SEO) is a hard beast to tame. Once you have everything just right, moving to a new platform, a new URL structure, or even a new domain can be stressful without taking the necessary steps first. Oh, you need a guide? Let me walk you through.
 
 <!--more-->

--- a/pages/articles/technical-deep-dives/the-ax-shift.md
+++ b/pages/articles/technical-deep-dives/the-ax-shift.md
@@ -5,6 +5,7 @@ layout: 'partials::layouts/writing-post'
 image: the-ax-shift-og.png
 heroImage: the-ax-shift-hero.png
 slug: the-ax-shift
+description: "The AX Shift is the move from designing software interfaces, documentation, and project context for humans to designing them for the agents now reading them. UX redesigned interfaces around users; DX redesigned APIs around the engineers consuming them; AX redesigns docs, context files, and specs around the autonomous agent that's now the primary reader."
 ---
 
 I kept improving my prompts.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,3 +18,13 @@
 
 ## Key topics
 Developer advocacy, payment APIs, SDK design, LLM context files, AEO/SEO, agent experience (AX), web presence management, fintech, developer experience (DX)
+
+## Projects
+- [claude-code-config](https://github.com/slogsdon/claude-code-config): Public Claude Code configuration. Skills, hooks, and plugins for AI-assisted development.
+- [modern-developer-design-system](https://github.com/slogsdon/modern-developer-design-system): Zero-runtime web components design system.
+- [shane.logsdon.io](https://github.com/slogsdon/shane.logsdon.io): Source for this site.
+
+## Contact
+- GitHub: https://github.com/slogsdon
+- LinkedIn: https://www.linkedin.com/in/shanelogsdon
+- Book a call: https://calendar.app.google/34ac2uYtwsR1NiTV6

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,41 @@
 User-agent: *
 Disallow: /thanks/
+
+# AI crawlers and answer-engine bots are explicitly welcome.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+Sitemap: https://shane.logsdon.io/sitemap.xml


### PR DESCRIPTION
## Summary

Adds Answer Engine Optimization (AEO) infrastructure across three commits:

- **llms.txt** ([b2f5a9e](https://github.com/slogsdon/shane.logsdon.io/commit/b2f5a9e)): adds Projects (claude-code-config, modern-developer-design-system, this site) and Contact (GitHub, LinkedIn, booking link) sections to the existing llms.txt.
- **robots.txt** ([0b54a52](https://github.com/slogsdon/shane.logsdon.io/commit/0b54a52)): rewrites robots.txt to explicitly welcome AI/answer-engine crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, OAI-SearchBot, CCBot, Bytespider, cohere-ai, anthropic-ai, etc.) and adds a Sitemap reference. The previous file already wasn't blocking these bots, but explicit Allow rules signal intent and protect against future-default disallow patterns.
- **article leads** ([9f84776](https://github.com/slogsdon/shane.logsdon.io/commit/9f84776)): seven articles whose first paragraph was a setup/teaser rather than a direct answer now lead with a ≤60-word direct answer to the title's implied question. Tutorial-style posts get an inline lead paragraph; the two recent literary essays (the-ax-shift, llm-context-files-are-deliverables-not-config) get a frontmatter `description` that the writing-post template renders as a deck above the body, which preserves the author's narrative opener.

Articles touched: application-deployment, migrating-from-mysql-server-to-percona-server, exploring-fsharp-with-dotnet-core-and-kestrel, fiddling-with-asp-dotnet-core-and-fsharp-with-suave, migrate-your-site-without-killing-your-search-engine-presence, llm-context-files-are-deliverables-not-config, the-ax-shift.

Articles intentionally left alone (lead already directly answers): asp-dotnet-core-webapi-in-azure-app-service, implementing-user-authentication-with-bcrypt-in-chicagoboss, writing-api-wrappers-with-elixir.

## Test plan

- [ ] Visit `/llms.txt` after deploy and confirm Projects + Contact sections render.
- [ ] Visit `/robots.txt` and confirm explicit Allow rules for AI crawlers + Sitemap line.
- [ ] Visit a touched article (e.g. `/articles/strategic-insights/migrating-from-mysql-server-to-percona-server/`) and confirm the lead paragraph renders.
- [ ] Visit `/articles/technical-deep-dives/the-ax-shift/` and confirm the description renders as a deck under the H1, and the literary opener still leads the body.
- [ ] Spot-check `<meta name="description">` on the two essays now reflects the new description.