### PR TITLE
feat: add FAQPage JSON-LD to article layout

### DIFF
--- a/pages/articles/technical-deep-dives/llm-context-files-are-deliverables-not-config.md
+++ b/pages/articles/technical-deep-dives/llm-context-files-are-deliverables-not-config.md
@@ -6,6 +6,13 @@ image: llm-context-files-are-deliverables-not-config-og.png
 heroImage: llm-context-files-are-deliverables-not-config-hero.png
 slug: llm-context-files-are-deliverables-not-config
 description: "An LLM context file like CLAUDE.md is a deliverable, not a config toggle. Configuration tells tools how to behave; a context file tells the agent what the project is, what's been decided, and what it needs to navigate the work. The first kind sets and forgets. The second has to be maintained."
+faqs:
+  - q: "What's the difference between a global and a project CLAUDE.md?"
+    a: "A global CLAUDE.md (typically at ~/.claude/CLAUDE.md) is the behavioral layer — it shapes how the agent works regardless of project, like answer first, flag speculation, ask before large changes. A project CLAUDE.md (at the repo root) is the contextual layer — it shapes what the agent knows about this codebase: stack, folder structure, conventions, and explicit boundaries. Both matter and do different jobs."
+  - q: "What should a CLAUDE.md actually contain?"
+    a: "Three categories. Invocation details: exact commands with full flags (npm test -- --coverage --watch=false, not 'run the tests'), explicit file paths, and at least one canonical code snippet for any pattern that matters. Process conventions: where tests live, coverage thresholds, branch naming, and commit message format. The boundary tier: what the agent can do autonomously (always), what requires a check-in (ask-first), and what's off the table regardless of context (never)."
+  - q: "Why do most CLAUDE.md files decay?"
+    a: "Teams write them as a snapshot of what the project is right now, rather than as a record of decisions that have been made. State descriptions go stale on their own; decision records compound. The fix is the self-improving pattern: when you catch yourself re-explaining something to the agent a second time, update the file in-session so future sessions inherit the correction. Prune stale lines aggressively, since the agent reads the whole file every time."
 ---
 
 I wrote my first CLAUDE.md in about fifteen minutes. It covered the tech stack, a few notes about TypeScript over JavaScript, a reminder about commit message format. It felt thorough. I didn't touch it for three months.

--- a/pages/articles/technical-deep-dives/the-ax-shift.md
+++ b/pages/articles/technical-deep-dives/the-ax-shift.md
@@ -6,6 +6,13 @@ image: the-ax-shift-og.png
 heroImage: the-ax-shift-hero.png
 slug: the-ax-shift
 description: "The AX Shift is the move from designing software interfaces, documentation, and project context for humans to designing them for the agents now reading them. UX redesigned interfaces around users; DX redesigned APIs around the engineers consuming them; AX redesigns docs, context files, and specs around the autonomous agent that's now the primary reader."
+faqs:
+  - q: "What is AX (Agent Experience)?"
+    a: "Agent Experience is the practice of designing artifacts — specs, context files, documentation, API responses — for AI agents operating autonomously between sessions, not just for human readers. It's the next iteration after UX (designed around users) and DX (designed around developer-consumers)."
+  - q: "Why doesn't writing better prompts fix AI coding drift?"
+    a: "Prompts are interaction-level adjustments, but drift is artifact-level. Excellent prompts running against an underdeveloped CLAUDE.md and a vague spec will still produce drift, because the agent is making design decisions you haven't recorded. Every ambiguous line in your spec or context file is a decision the agent will make for you, in the direction of statistical probability."
+  - q: "Where should teams invest for reliable AI-assisted development?"
+    a: "Not in model selection or prompt engineering. Invest in the artifacts that give agents reliable context across sessions: a CLAUDE.md that's updated after every session, design specs authoritative enough that gap analyses can be written against them, and implementation tasks derived from the spec rather than improvised from the conversation."
 ---
 
 I kept improving my prompts.

--- a/resources/partials/layouts/writing-post.php
+++ b/resources/partials/layouts/writing-post.php
@@ -206,3 +206,19 @@ $venue = isset($meta->presentationMetadata) && is_array($meta->presentationMetad
     }
 }
 </script>
+
+<?php if (!empty($faqs) && is_array($faqs)): ?>
+<script type="application/ld+json">
+<?= json_encode([
+    '@context' => 'https://schema.org',
+    '@type' => 'FAQPage',
+    '@id' => 'https://shane.logsdon.io' . $url . '#FAQPage',
+    'url' => 'https://shane.logsdon.io' . $url,
+    'mainEntity' => array_map(fn($faq) => [
+        '@type' => 'Question',
+        'name' => $faq['q'],
+        'acceptedAnswer' => ['@type' => 'Answer', 'text' => $faq['a']],
+    ], $faqs),
+], JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?>
+</script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- Article layout (`resources/partials/layouts/writing-post.php`) now emits a `FAQPage` JSON-LD block alongside the existing `Article` schema when an article declares a `faqs:` array in YAML frontmatter (q/a pairs). Pattern matches the existing `FAQPage` block on `/services/`.
- Adds 3 FAQ entries each to the two recent technical-deep-dives posts:
  - [The AX Shift: You're Still Designing for Yourself](pages/articles/technical-deep-dives/the-ax-shift.md)
  - [LLM Context Files Are Deliverables, Not Config](pages/articles/technical-deep-dives/llm-context-files-are-deliverables-not-config.md)
- Goal: improve AI citation and answer-engine visibility for the Agentic Product Development series. Legacy posts without `faqs:` are unchanged.

## Notes
- Optional per-article via frontmatter — no global injection, no schema noise on posts that don't have a clear FAQ surface.
- FAQ copy is derived from each post's lead and key section claims, not new content.
- Existing `Article` JSON-LD (with `@id`, `mainEntityOfPage` semantics, author/publisher) is preserved verbatim.

## Test plan
- [x] `composer run build` succeeds.
- [x] Built HTML for both updated articles contains both `Article` and `FAQPage` JSON-LD blocks; both parse as valid JSON.
- [x] A legacy article (`exploring-fsharp-with-dotnet-core-and-kestrel`) still emits exactly one `Article` JSON-LD block — no FAQPage regression.
- [ ] After merge, validate live URLs in Google's Rich Results Test and Schema.org validator.